### PR TITLE
fixing repo links

### DIFF
--- a/ir-plugins.manifest.json
+++ b/ir-plugins.manifest.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "project-manifest",
   "packages": [
-    "https://github.com/ir/ir-bot",
-    "https://github.com/ir/ir-development-test-suite"
+    "https://github.com/ir-engine/ir-bot",
+    "https://github.com/ir-engine/ir-development-test-suite"
   ]
 }


### PR DESCRIPTION
`/ir/` instead of `/ir-engine/` fixed