### PR TITLE
Manifest updates for successful install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 To install all official open source projects for local development, use the following scripts inside your iR engine installation.
 
+Install the core contributor test suite
+```bash
+npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-core.manifest.json" --branch="dev"
+```
+
+Install all plugins
+```bash
+npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-plugins.manifest.json" --branch="dev"
+```
+
 Install the demo scenes
 ```bash
 npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-scenes.manifest.json" --branch="dev"
@@ -10,16 +20,6 @@ npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-
 Install all the tutorials
 ```bash
 npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-tutorials.manifest.json" --branch="dev"
-```
-
-Install all plugins
-```bash
-npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-plugins.manifest.json" --branch="dev"
-```
-
-Install the core contributor test suite
-```bash
-npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-core.manifest.json" --branch="dev"
 ```
 
 Note: to allow private repos to install correctly:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-
 ```
 
 Install all the tutorials
+
+*ir-tutorial-pong was removed from the tutorial manifest due to import errors, but should be added back when fixed.*
 ```bash
 npm run install-manifest -- --manifestURL="https://github.com/ir-engine/project-manifest/blob/main/ir-tutorials.manifest.json" --branch="dev"
 ```

--- a/ir-tutorials.manifest.json
+++ b/ir-tutorials.manifest.json
@@ -4,7 +4,6 @@
   "packages": [
     "https://github.com/ir-engine/ir-tutorial-hello",
     "https://github.com/ir-engine/ir-tutorial-bubbles",
-    "https://github.com/ir-engine/ir-tutorial-basic",
-    "https://github.com/ir-engine/ir-tutorial-pong"
+    "https://github.com/ir-engine/ir-tutorial-basic"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+    "name": "ir-engine/project-manifest",
+    "version": "0.0.0",
+    "engineVersion": "1.6.0",
+    "description": "A meta-project for installing various project bundles for the iR Engine"
+  }


### PR DESCRIPTION
Added manifest.json to match the convention across other projects and resolve an `npm run dev-reinit` error.

Removed ir-tutorial-pong as it is out of date and imports nonexistent files from `@ir-engine/spatial/` causing errors when running the engine. Noted in README.

Alphabetized README links to match the display order of the manifest files, for easier cross-reference.